### PR TITLE
Add random starting team and counters

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
         <button id="nuevoJuego">Nuevo Juego</button>
         <button id="vistaEspia">Ver/Ocultar Vista del Espía</button>
     </div>
+    <div id="informacion">
+        <p id="turno"></p>
+        <p>Cartas restantes - Rojo: <span id="rojoRestantes"></span> | Azul: <span id="azulRestantes"></span></p>
+    </div>
     <div id="tablero"></div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const tablero = document.getElementById('tablero');
     const botonNuevoJuego = document.getElementById('nuevoJuego');
     const botonVistaEspia = document.getElementById('vistaEspia');
+    const turnoTexto = document.getElementById('turno');
+    const rojoRestantes = document.getElementById('rojoRestantes');
+    const azulRestantes = document.getElementById('azulRestantes');
 
     // --- ¡EDITA ESTA LISTA PARA USAR TUS PROPIAS PALABRAS! ---
     const palabras = [
@@ -12,14 +15,28 @@ document.addEventListener('DOMContentLoaded', () => {
     ];
     // --- FIN DE LA LISTA DE PALABRAS ---
 
+    let restantes;
+    let equipoInicial;
+
+    function actualizarContador() {
+        rojoRestantes.textContent = restantes.rojo;
+        azulRestantes.textContent = restantes.azul;
+    }
+
     function iniciarJuego() {
         tablero.innerHTML = '';
         tablero.classList.remove('vista-espia');
         const palabrasJuego = palabras.sort(() => 0.5 - Math.random()).slice(0, 25);
+
+        equipoInicial = Math.random() < 0.5 ? 'rojo' : 'azul';
+        restantes = { rojo: equipoInicial === 'rojo' ? 9 : 8, azul: equipoInicial === 'azul' ? 9 : 8 };
+        turnoTexto.textContent = `Empieza el equipo ${equipoInicial.toUpperCase()}`;
+        actualizarContador();
+
         let roles = [];
-        for (let i = 0; i < 8; i++) roles.push('rojo');
-        for (let i = 0; i < 8; i++) roles.push('azul');
-        for (let i = 0; i < 8; i++) roles.push('neutro');
+        for (let i = 0; i < restantes.rojo; i++) roles.push('rojo');
+        for (let i = 0; i < restantes.azul; i++) roles.push('azul');
+        for (let i = 0; i < 7; i++) roles.push('neutro');
         roles.push('asesino');
         roles = roles.sort(() => 0.5 - Math.random());
         palabrasJuego.forEach((palabra, i) => {
@@ -28,8 +45,13 @@ document.addEventListener('DOMContentLoaded', () => {
             tarjeta.textContent = palabra;
             tarjeta.dataset.rol = roles[i];
             tarjeta.addEventListener('click', () => {
+                if (tarjeta.classList.contains('revelada')) return;
                 tarjeta.classList.add('revelada');
                 tarjeta.classList.add(tarjeta.dataset.rol);
+                if (tarjeta.dataset.rol === 'rojo' || tarjeta.dataset.rol === 'azul') {
+                    restantes[tarjeta.dataset.rol]--;
+                    actualizarContador();
+                }
             });
             tablero.appendChild(tarjeta);
         });

--- a/style.css
+++ b/style.css
@@ -15,6 +15,10 @@ button {
     border-radius: 5px;
     margin: 5px;
 }
+#informacion {
+    margin: 10px 0;
+    font-weight: bold;
+}
 #tablero {
     display: grid;
     grid-template-columns: repeat(5, 1fr);


### PR DESCRIPTION
## Summary
- randomly pick starting team in game initialization
- show which team starts and the remaining cards for each team
- display card counters and update them on reveal

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846a97029688327aa3e844d194f85da