### PR TITLE
Remove rotation effect on card reveal

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,7 +54,7 @@ select {
 .vista-espia .tarjeta.neutro { background-color: #fdffb6; }
 .vista-espia .tarjeta.asesino { background-color: #444; color: white; }
 .tarjeta.revelada {
-    transform: rotateY(180deg);
+    transform: none;
     color: white;
 }
 .tarjeta.revelada.rojo { background-color: #d90429; }


### PR DESCRIPTION
## Summary
- remove rotateY animation so revealed cards only change color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846ac726228832794563c719eaac9d7