### PR TITLE
Fix JSON syntax in nombres.json

### DIFF
--- a/nombres.json
+++ b/nombres.json
@@ -25,7 +25,7 @@
     "Sari",
     "Carlos",
     "Espejo",
-    "Luc\u00eda"
+    "Luc\u00eda",
     "casa",
   "coche",
   "perro",


### PR DESCRIPTION
## Summary
- fix typo in `nombres.json` list that prevented valid JSON parsing

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('nombres.json','utf8')); console.log('JSON ok');"`


------
https://chatgpt.com/codex/tasks/task_e_6846ad3f713083278db3cd0abf9b3b15