### PR TITLE
Fix card reveal color

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,3 +107,9 @@ select {
     color: white;
 }
 
+/* Colores para cada rol cuando se revela una tarjeta */
+.tarjeta.revelada.rojo { background-color: #ffadad; }
+.tarjeta.revelada.azul { background-color: #a0c4ff; }
+.tarjeta.revelada.neutro { background-color: #fdffb6; color: black; }
+.tarjeta.revelada.asesino { background-color: #444; color: white; }
+


### PR DESCRIPTION
## Summary
- ensure revealed cards show the proper color

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846aea048408327a796eb96567dbdfc