### PR TITLE
Add team turn buttons and colorized title

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,9 @@
         </select>
         <button id="nuevoJuego">Nuevo Juego</button>
         <button id="vistaEspia">Ver/Ocultar Vista del Espía</button>
+        <button id="equipoRojo">Equipo Rojo</button>
+        <button id="equipoAzul">Equipo Azul</button>
+        <button id="terminarTurno">Terminar Turno</button>
     </div>
     <div id="informacion">
         <p id="turno"></p>

--- a/script.js
+++ b/script.js
@@ -3,10 +3,27 @@ document.addEventListener('DOMContentLoaded', () => {
     const botonNuevoJuego = document.getElementById('nuevoJuego');
     const botonVistaEspia = document.getElementById('vistaEspia');
     const tamanoGridSelect = document.getElementById('tamanoGrid');
+    const botonEquipoRojo = document.getElementById('equipoRojo');
+    const botonEquipoAzul = document.getElementById('equipoAzul');
+    const botonTerminarTurno = document.getElementById('terminarTurno');
 
     const turnoTexto = document.getElementById('turno');
     const rojoRestantes = document.getElementById('rojoRestantes');
     const azulRestantes = document.getElementById('azulRestantes');
+
+    function colorearTitulo() {
+        const titulo = document.querySelector('h1');
+        const texto = titulo.textContent;
+        titulo.innerHTML = '';
+        [...texto].forEach((letra, idx) => {
+            const span = document.createElement('span');
+            span.textContent = letra;
+            if (letra.trim() !== '') {
+                span.classList.add(idx % 2 === 0 ? 'rojo' : 'azul');
+            }
+            titulo.appendChild(span);
+        });
+    }
 
 
     let palabras = [];
@@ -24,6 +41,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let restantes;
     let equipoInicial;
+    let equipoActual;
+
+    function mostrarTurno(mensajeInicio = false) {
+        if (mensajeInicio) {
+            turnoTexto.textContent = `Empieza el equipo ${equipoActual.toUpperCase()}`;
+        } else {
+            turnoTexto.textContent = `Turno de: EQUIPO ${equipoActual.toUpperCase()}`;
+        }
+        turnoTexto.classList.remove('rojo', 'azul');
+        turnoTexto.classList.add(equipoActual);
+    }
 
     function actualizarContador() {
         rojoRestantes.textContent = restantes.rojo;
@@ -51,7 +79,8 @@ document.addEventListener('DOMContentLoaded', () => {
             rojo: equipoInicial === 'rojo' ? base : base - 1,
             azul: equipoInicial === 'azul' ? base : base - 1
         };
-        turnoTexto.textContent = `Empieza el equipo ${equipoInicial.toUpperCase()}`;
+        equipoActual = equipoInicial;
+        mostrarTurno(true);
         actualizarContador();
 
         let roles = [];
@@ -96,5 +125,21 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    botonEquipoRojo.addEventListener('click', () => {
+        equipoActual = 'rojo';
+        mostrarTurno();
+    });
+
+    botonEquipoAzul.addEventListener('click', () => {
+        equipoActual = 'azul';
+        mostrarTurno();
+    });
+
+    botonTerminarTurno.addEventListener('click', () => {
+        equipoActual = equipoActual === 'rojo' ? 'azul' : 'rojo';
+        mostrarTurno();
+    });
+
+    colorearTitulo();
     cargarPalabras().then(iniciarJuego);
 });

--- a/style.css
+++ b/style.css
@@ -36,18 +36,7 @@ main {
 h1 {
     margin: 0;
     font-size: 3rem;
-    background: linear-gradient(90deg, #ff416c, #ff4b2b, #ff416c);
-    background-size: 200% auto;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    animation: tituloEfecto 5s linear infinite;
     text-shadow: 2px 2px 6px rgba(0,0,0,0.3);
-}
-
-@keyframes tituloEfecto {
-    0% { background-position: 0% 50%; }
-    50% { background-position: 100% 50%; }
-    100% { background-position: 0% 50%; }
 }
 .controles { margin: 20px; }
 button {
@@ -123,4 +112,12 @@ select {
 .tarjeta.revelada.azul { background-color: #a0c4ff; }
 .tarjeta.revelada.neutro { background-color: #fdffb6; color: black; }
 .tarjeta.revelada.asesino { background-color: #444; color: white; }
+
+#turno {
+    font-weight: bold;
+    margin: 10px 0;
+}
+
+.rojo { color: #ff0000; }
+.azul { color: #0000ff; }
 


### PR DESCRIPTION
## Summary
- add Equipo Rojo, Equipo Azul and Terminar Turno buttons
- alternate colors on the title letters
- display and switch team turns in the interface
- tweak CSS for new text color classes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846b0a58d308327af2aa321e4c99511