### PR TITLE
Add confirmation for card reveal

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
         <p>Cartas restantes - Rojo: <span id="rojoRestantes"></span> | Azul: <span id="azulRestantes"></span></p>
     </div>
     <div id="tablero"></div>
+    <button id="confirmar" disabled>Confirmar</button>
     <div id="configTooltip" class="tooltip oculto">
         <div class="tooltip-contenido">
             <h2>Configurar Juego</h2>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const botonEquipoRojo = document.getElementById('equipoRojo');
     const botonEquipoAzul = document.getElementById('equipoAzul');
     const botonTerminarTurno = document.getElementById('terminarTurno');
+    const botonConfirmar = document.getElementById('confirmar');
 
 
     const tooltip = document.getElementById('configTooltip');
@@ -63,6 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let restantes;
     let equipoInicial;
     let equipoActual;
+    let tarjetaSeleccionada = null;
 
     function mostrarTurno(mensajeInicio = false) {
         if (mensajeInicio) {
@@ -82,6 +84,9 @@ document.addEventListener('DOMContentLoaded', () => {
     function iniciarJuego(tamano = tamanoActual, listaPalabras = null) {
         tamanoActual = tamano;
         document.documentElement.style.setProperty('--grid-size', tamanoActual);
+
+        botonConfirmar.disabled = true;
+        tarjetaSeleccionada = null;
 
         const listaPalabras = obtenerListaNivel(nivelSelect.value);
 
@@ -123,13 +128,12 @@ document.addEventListener('DOMContentLoaded', () => {
             tarjeta.dataset.rol = roles[i];
             tarjeta.addEventListener('click', () => {
                 if (tarjeta.classList.contains('revelada')) return;
-                tarjeta.classList.add('revelada');
-                tarjeta.classList.add(tarjeta.dataset.rol);
-                if (tarjeta.dataset.rol === 'rojo' || tarjeta.dataset.rol === 'azul') {
-                    restantes[tarjeta.dataset.rol]--;
-                    actualizarContador();
+                if (tarjetaSeleccionada) {
+                    tarjetaSeleccionada.classList.remove('seleccionada');
                 }
-
+                tarjetaSeleccionada = tarjeta;
+                tarjeta.classList.add('seleccionada');
+                botonConfirmar.disabled = false;
             });
             tablero.appendChild(tarjeta);
         });
@@ -193,6 +197,20 @@ document.addEventListener('DOMContentLoaded', () => {
     botonTerminarTurno.addEventListener('click', () => {
         equipoActual = equipoActual === 'rojo' ? 'azul' : 'rojo';
         mostrarTurno();
+    });
+
+    botonConfirmar.addEventListener('click', () => {
+        if (!tarjetaSeleccionada) return;
+        const tarjeta = tarjetaSeleccionada;
+        tarjeta.classList.remove('seleccionada');
+        tarjeta.classList.add('revelada');
+        tarjeta.classList.add(tarjeta.dataset.rol);
+        if (tarjeta.dataset.rol === 'rojo' || tarjeta.dataset.rol === 'azul') {
+            restantes[tarjeta.dataset.rol]--;
+            actualizarContador();
+        }
+        tarjetaSeleccionada = null;
+        botonConfirmar.disabled = true;
     });
 
     colorearTitulo();

--- a/style.css
+++ b/style.css
@@ -153,6 +153,21 @@ select {
     display: none;
 }
 
+/* Efecto de parpadeo para la tarjeta seleccionada */
+@keyframes parpadeo {
+    0%, 100% { box-shadow: 0 0 10px rgba(255, 215, 0, 0.8); }
+    50% { box-shadow: 0 0 10px rgba(255, 215, 0, 0.2); }
+}
+
+.tarjeta.seleccionada {
+    animation: parpadeo 1s infinite;
+}
+
+button:disabled {
+    background: #ccc;
+    cursor: not-allowed;
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- add a Confirmar button to allow confirming card selection
- implement flashing animation for selected card
- disable button until a card is chosen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846b5f1b6f883278bc2ad3d099fab00