### PR TITLE
Add spy-themed console font

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Códigos Secretos</title>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -18,7 +18,7 @@
 }
 
 body {
-    font-family: 'Poppins', sans-serif;
+    font-family: 'Share Tech Mono', 'Poppins', monospace;
     text-align: center;
     color: #333;
     margin: 0;
@@ -34,6 +34,7 @@ main {
 }
 
 h1 {
+    font-family: "Share Tech Mono", monospace;
     margin: 0;
     font-size: 3rem;
     text-shadow: 2px 2px 6px rgba(0,0,0,0.3);
@@ -72,6 +73,7 @@ select {
     margin: 20px auto;
 }
 .tarjeta {
+    font-family: "Share Tech Mono", monospace;
     background-color: #fff;
     border: 2px solid #ddd;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- use Share Tech Mono from Google Fonts for a spy-console feel
- apply the new font to the body, heading and cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846b959c2ec83279b5ff89f801a69b5