### PR TITLE
Improve selection flow with confirmation step

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
         <button id="nuevoJuego">Nuevo Juego</button>
         <button id="vistaEspia">Ver/Ocultar Vista del Espía</button>
         <button id="terminarTurno">Terminar Turno</button>
+        <button id="confirmar" disabled>Confirmar</button>
     </div>
     <div id="informacion">
         <p id="turno"></p>
@@ -38,7 +39,6 @@
     <div id="tablero"></div>
     <div id="mensajeVictoria" class="mensaje-victoria oculto"></div>
 
-    <button id="confirmar" disabled>Confirmar</button>
 
     <div id="configTooltip" class="tooltip oculto">
         <div class="tooltip-contenido">

--- a/script.js
+++ b/script.js
@@ -132,19 +132,6 @@ document.addEventListener('DOMContentLoaded', () => {
             tarjeta.dataset.rol = roles[i];
             tarjeta.addEventListener('click', () => {
                 if (tarjeta.classList.contains('revelada') || juegoTerminado) return;
-                tarjeta.classList.add('revelada');
-                tarjeta.classList.add(tarjeta.dataset.rol);
-                if (tarjeta.dataset.rol === 'asesino') {
-                    juegoTerminado = true;
-                    const ganador = equipoActual === 'rojo' ? 'azul' : 'rojo';
-                    mostrarMensajeVictoria(ganador);
-                    return;
-                }
-                if (tarjeta.dataset.rol === 'rojo' || tarjeta.dataset.rol === 'azul') {
-                    restantes[tarjeta.dataset.rol]--;
-                    actualizarContador();
-                }
-                if (tarjeta.classList.contains('revelada')) return;
                 if (tarjetaSeleccionada) {
                     tarjetaSeleccionada.classList.remove('seleccionada');
                 }
@@ -209,15 +196,27 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     botonConfirmar.addEventListener('click', () => {
-        if (!tarjetaSeleccionada) return;
+        if (!tarjetaSeleccionada || juegoTerminado) return;
         const tarjeta = tarjetaSeleccionada;
         tarjeta.classList.remove('seleccionada');
         tarjeta.classList.add('revelada');
         tarjeta.classList.add(tarjeta.dataset.rol);
-        if (tarjeta.dataset.rol === 'rojo' || tarjeta.dataset.rol === 'azul') {
-            restantes[tarjeta.dataset.rol]--;
-            actualizarContador();
+
+        if (tarjeta.dataset.rol === 'asesino') {
+            juegoTerminado = true;
+            const ganador = equipoActual === 'rojo' ? 'azul' : 'rojo';
+            mostrarMensajeVictoria(ganador);
+        } else {
+            if (tarjeta.dataset.rol === 'rojo' || tarjeta.dataset.rol === 'azul') {
+                restantes[tarjeta.dataset.rol]--;
+                actualizarContador();
+                if (restantes[tarjeta.dataset.rol] === 0) {
+                    juegoTerminado = true;
+                    mostrarMensajeVictoria(tarjeta.dataset.rol);
+                }
+            }
         }
+
         tarjetaSeleccionada = null;
         botonConfirmar.disabled = true;
     });


### PR DESCRIPTION
## Summary
- reposition Confirmar button with other controls
- change card click logic to only select the card
- reveal card on confirm button click and handle victory

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846b9e2a2248327b2c4353d4f2ccddf