### PR TITLE
Fix victory message visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,8 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const azulRestantes = document.getElementById('azulRestantes');
     const mensajeVictoria = document.getElementById('mensajeVictoria');
 
-    // Oculta el mensaje de victoria al hacer clic en cualquier parte
-    document.addEventListener('click', () => {
+    // Permite cerrar el mensaje de victoria al hacer clic en él
+    mensajeVictoria.addEventListener('click', (e) => {
+        e.stopPropagation();
         mensajeVictoria.classList.add('oculto');
     });
 


### PR DESCRIPTION
## Summary
- adjust handler so victory message isn't hidden immediately on click

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6846bb6eb9c083278a84f9537ee09be8