### PR TITLE
Enhance confirm button and selection highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,11 +24,13 @@
         <button id="nuevoJuego">Nuevo Juego</button>
         <button id="vistaEspia">Ver/Ocultar Vista del Espía</button>
         <button id="terminarTurno">Terminar Turno</button>
-        <button id="confirmar" disabled>Confirmar</button>
     </div>
     <div id="informacion">
         <p id="turno"></p>
         <p>Cartas restantes - Rojo: <span id="rojoRestantes"></span> | Azul: <span id="azulRestantes"></span></p>
+    </div>
+    <div class="confirmar-wrapper">
+        <button id="confirmar" disabled>Confirmar</button>
     </div>
     <div id="tablero"></div>
     <div id="mensajeVictoria" class="mensaje-victoria oculto"></div>

--- a/style.css
+++ b/style.css
@@ -189,11 +189,35 @@ select {
 
 .tarjeta.seleccionada {
     animation: parpadeo 1s infinite;
+    background: radial-gradient(circle at center, #d2b48c, #8b4513);
+    color: #fff;
 }
 
 button:disabled {
     background: #ccc;
     cursor: not-allowed;
+}
+
+.confirmar-wrapper {
+    margin: 10px 0 20px;
+    display: flex;
+    justify-content: center;
+}
+
+#confirmar {
+    background-color: #ff3333;
+    border-radius: 50%;
+    width: 80px;
+    height: 80px;
+    font-size: 1rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    border: 4px solid #b30000;
+    box-shadow: 0 0 10px rgba(255, 0, 0, 0.7), inset 0 0 5px rgba(255,255,255,0.5);
+}
+#confirmar:hover:not(:disabled) {
+    box-shadow: 0 0 15px rgba(255, 0, 0, 0.9), inset 0 0 5px rgba(255,255,255,0.8);
+    transform: scale(1.05);
 }
 
 


### PR DESCRIPTION
## Summary
- emphasize the selected card with a bright brown gradient
- move the **Confirmar** button below the card counters
- style the confirm button as a large red detonator-like button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846bbb949288327b9ac63a4144ff959