### PR TITLE
Style confirm button with circular text

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,18 @@
         <p>Cartas restantes - Rojo: <span id="rojoRestantes"></span> | Azul: <span id="azulRestantes"></span></p>
     </div>
     <div class="confirmar-wrapper">
-        <button id="confirmar" disabled>Confirmar</button>
+        <button id="confirmar" disabled>
+            <svg class="confirmar-svg" viewBox="0 0 100 100">
+                <defs>
+                    <path id="trayectoria" d="M50,50 m-35,0 a35,35 0 1,1 70,0 a35,35 0 1,1 -70,0" />
+                </defs>
+                <text class="confirmar-texto">
+                    <textPath href="#trayectoria" startOffset="50%" text-anchor="middle">
+                        Confirmar
+                    </textPath>
+                </text>
+            </svg>
+        </button>
     </div>
     <div id="tablero"></div>
     <div id="mensajeVictoria" class="mensaje-victoria oculto"></div>

--- a/style.css
+++ b/style.css
@@ -218,15 +218,27 @@ button:disabled {
     border-radius: 50%;
     width: 80px;
     height: 80px;
-    font-size: 1rem;
-    font-weight: bold;
-    text-transform: uppercase;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     border: 4px solid #b30000;
     box-shadow: 0 0 10px rgba(255, 0, 0, 0.7), inset 0 0 5px rgba(255,255,255,0.5);
 }
 #confirmar:hover:not(:disabled) {
     box-shadow: 0 0 15px rgba(255, 0, 0, 0.9), inset 0 0 5px rgba(255,255,255,0.8);
     transform: scale(1.05);
+}
+
+.confirmar-svg {
+    width: 70px;
+    height: 70px;
+}
+
+.confirmar-texto {
+    fill: #fff;
+    font-size: 0.75rem;
+    font-weight: bold;
 }
 
 


### PR DESCRIPTION
## Summary
- embed an SVG in the Confirmar button so text follows a circular path
- adjust styles for the confirm button and its SVG text

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846be3dcf648327a1955933f4559f41