### PR TITLE
Add mode guidance and disable input when normal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ las palabras que se mostrarán en el tablero a partir del archivo
 `nombres.json`. Puedes modificar ese archivo para usar tus propias
 palabras.
 
-Al pulsar **Nuevo Juego** se abrirá un pequeño panel de configuración.
-Ahí eliges el tamaño del tablero y puedes introducir palabras
-propias separadas por comas. Si seleccionas el modo
-"Personalizado" deberás escribir exactamente el número de palabras
-que quepan en el tablero. También puedes escoger añadir esas
-palabras a la lista existente.
+Al pulsar **Nuevo Juego** se abre un panel de configuración.
+En modo **Normal** la caja de texto está deshabilitada y muestra que se
+utilizarán 25, 16 o 9 palabras al azar, dependiendo del tamaño
+del tablero.
+Si eliges el modo **Personalizado** deberás escribir exactamente 25, 16 o
+9 palabras separadas por comas. Con la opción **Añadir palabras** puedes
+introducir palabras opcionales que se sumarán a las ya seleccionadas.

--- a/script.js
+++ b/script.js
@@ -18,6 +18,25 @@ document.addEventListener('DOMContentLoaded', () => {
     const cancelarJuegoBtn = document.getElementById('cancelarJuego');
     const modoRadios = document.getElementsByName('modoJuego');
 
+    modoRadios.forEach(r => r.addEventListener('change', actualizarPalabrasInput));
+
+    function actualizarPalabrasInput() {
+        let modo = 'normal';
+        modoRadios.forEach(r => { if (r.checked) modo = r.value; });
+        if (modo === 'normal') {
+            palabrasInput.disabled = true;
+            palabrasInput.value = '25 palabras / 16 o 9 palabras seleccionadas al azar.';
+        } else if (modo === 'custom') {
+            palabrasInput.disabled = false;
+            palabrasInput.value = '';
+            palabrasInput.placeholder = 'Incluye 25/16 o 9 palabras separadas por coma.';
+        } else {
+            palabrasInput.disabled = false;
+            palabrasInput.value = '';
+            palabrasInput.placeholder = 'Puedes añadir palabras opcionalmente para complementar las elegidas (25/16 o 9).';
+        }
+    }
+
 
     const turnoTexto = document.getElementById('turno');
     const rojoRestantes = document.getElementById('rojoRestantes');
@@ -158,6 +177,7 @@ document.addEventListener('DOMContentLoaded', () => {
         nivelTooltip.value = nivelActual;
         palabrasInput.value = '';
         modoRadios.forEach(r => r.checked = r.value === 'normal');
+        actualizarPalabrasInput();
     });
 
     comenzarJuegoBtn.addEventListener('click', () => {
@@ -166,7 +186,10 @@ document.addEventListener('DOMContentLoaded', () => {
         let modo = 'normal';
         modoRadios.forEach(r => { if (r.checked) modo = r.value; });
         const palabrasBase = obtenerListaNivel(nivelActual);
-        const ingresadas = palabrasInput.value.split(',').map(p => p.trim()).filter(p => p);
+        let ingresadas = [];
+        if (modo !== 'normal') {
+            ingresadas = palabrasInput.value.split(',').map(p => p.trim()).filter(p => p);
+        }
         let listaFinal;
 
         if (modo === 'custom') {


### PR DESCRIPTION
## Summary
- disable the custom words box for Normal mode
- show helpful placeholder text when choosing Custom or Add words
- clarify configuration instructions in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846beeafd0883278380f4ecf0215986