### PR TITLE
Add tablet mode with dual-facing card text

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         <button id="nuevoJuego">Nuevo Juego</button>
         <button id="vistaEspia">Ver/Ocultar Vista del Espía</button>
         <button id="terminarTurno">Terminar Turno</button>
+        <button id="tabletMode">📱 Tablet Mode</button>
     </div>
     <div id="informacion">
         <p id="turno"></p>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const tablero = document.getElementById('tablero');
     const botonNuevoJuego = document.getElementById('nuevoJuego');
     const botonVistaEspia = document.getElementById('vistaEspia');
+    const botonTabletMode = document.getElementById('tabletMode');
 
     const tamanoGridSelect = document.getElementById('tamanoGrid');
 
@@ -158,6 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
             tarjeta.classList.add('tarjeta');
             tarjeta.textContent = palabra;
             tarjeta.dataset.rol = roles[i];
+            tarjeta.dataset.palabra = palabra;
             tarjeta.addEventListener('click', () => {
                 if (tarjeta.classList.contains('revelada') || juegoTerminado) return;
                 if (tarjetaSeleccionada) {
@@ -219,6 +221,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     botonVistaEspia.addEventListener('click', () => {
         tablero.classList.toggle('vista-espia');
+    });
+
+    botonTabletMode.addEventListener('click', () => {
+        tablero.classList.toggle('modo-tablet');
     });
 
 

--- a/style.css
+++ b/style.css
@@ -101,6 +101,23 @@ select {
     box-shadow: 0 6px 10px rgba(0,0,0,0.2);
 }
 
+#tablero.modo-tablet .tarjeta {
+    position: relative;
+    justify-content: flex-end;
+    padding-bottom: 0.4em;
+}
+
+#tablero.modo-tablet .tarjeta::before {
+    content: attr(data-palabra);
+    position: absolute;
+    top: 0.4em;
+    left: 0;
+    right: 0;
+    text-align: center;
+    transform: rotate(180deg);
+    pointer-events: none;
+}
+
 .vista-espia .tarjeta.rojo { background-color: #ffadad; }
 .vista-espia .tarjeta.azul { background-color: #a0c4ff; }
 .vista-espia .tarjeta.neutro { background-color: #fdffb6; }


### PR DESCRIPTION
## Summary
- add Tablet Mode button with emoji
- support toggling tablet mode in JS
- show words in both directions when tablet mode is active

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846c0601ff08327a383b8e394cfdd4a