### PR TITLE
Improve team wrappers visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,16 +101,32 @@ select {
     box-shadow: 0 6px 10px rgba(0,0,0,0.2);
 }
 
-.vista-espia .tarjeta.rojo { background-color: #ffadad; }
-.vista-espia .tarjeta.azul { background-color: #a0c4ff; }
+.vista-espia .tarjeta.rojo {
+    background-color: #ffadad;
+    color: #fff;
+    font-weight: bold;
+}
+.vista-espia .tarjeta.azul {
+    background-color: #a0c4ff;
+    color: #fff;
+    font-weight: bold;
+}
 .vista-espia .tarjeta.neutro { background-color: #fdffb6; }
 .vista-espia .tarjeta.asesino { background-color: #444; color: white; }
 
 
 
 .tarjeta:hover { transform: scale(1.05); }
-.vista-espia .tarjeta[data-rol="rojo"]:not(.revelada) { background-color: #ffadad; }
-.vista-espia .tarjeta[data-rol="azul"]:not(.revelada) { background-color: #a0c4ff; }
+.vista-espia .tarjeta[data-rol="rojo"]:not(.revelada) {
+    background-color: #ffadad;
+    color: #fff;
+    font-weight: bold;
+}
+.vista-espia .tarjeta[data-rol="azul"]:not(.revelada) {
+    background-color: #a0c4ff;
+    color: #fff;
+    font-weight: bold;
+}
 .vista-espia .tarjeta[data-rol="neutro"]:not(.revelada) { background-color: #fdffb6; }
 .vista-espia .tarjeta[data-rol="asesino"]:not(.revelada) { background-color: #444; color: white; }
 
@@ -186,8 +202,14 @@ select {
     z-index: 2000;
     background: rgba(255,255,255,0.95);
 }
-.mensaje-victoria.rojo { background-color: #ffadad; color: #b30000; }
-.mensaje-victoria.azul { background-color: #a0c4ff; color: #0033cc; }
+.mensaje-victoria.rojo {
+    background-color: #ffadad;
+    color: #fff;
+}
+.mensaje-victoria.azul {
+    background-color: #a0c4ff;
+    color: #fff;
+}
 .mensaje-victoria.oculto { display: none; }
 /* Efecto de parpadeo para la tarjeta seleccionada */
 @keyframes parpadeo {


### PR DESCRIPTION
## Summary
- ensure spy mode cards use white text with bold font
- make victory text white for better contrast

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846c0decb0483278aa0dc5aa2eb27c1