### PR TITLE
Fix team badge text color

### DIFF
--- a/style.css
+++ b/style.css
@@ -151,7 +151,7 @@ select {
     display: inline-block;
     padding: 5px 12px;
     border-radius: 6px;
-    color: #fff;
+    color: #fff !important;
     font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- force white text on the turn indicator badges

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846c2b51cc88327bc045a7192f51fc4