### PR TITLE
Remove board size control from game board

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,13 +14,6 @@
     </header>
     <main>
     <div class="controles">
-        <label for="tamanoGrid">Tamaño del tablero:</label>
-        <select id="tamanoGrid">
-            <option value="5" selected>5x5</option>
-            <option value="4">4x4</option>
-            <option value="3">3x3</option>
-        </select>
-
         <button id="nuevoJuego">Nuevo Juego</button>
         <button id="vistaEspia">Ver/Ocultar Vista del Espía</button>
         <button id="terminarTurno">Terminar Turno</button>

--- a/script.js
+++ b/script.js
@@ -4,9 +4,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const botonVistaEspia = document.getElementById('vistaEspia');
     const botonTabletMode = document.getElementById('tabletMode');
 
-    const tamanoGridSelect = document.getElementById('tamanoGrid');
-
-
     const botonTerminarTurno = document.getElementById('terminarTurno');
     const botonConfirmar = document.getElementById('confirmar');
 
@@ -67,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let palabrasA1 = [];
     let palabrasA2 = [];
-    let tamanoActual = parseInt(tamanoGridSelect.value);
+    let tamanoActual = 5; // tamaño por defecto del tablero
     let nivelActual = nivelTooltip.value;
 
     document.documentElement.style.setProperty('--grid-size', tamanoActual);


### PR DESCRIPTION
## Summary
- remove tablero size selector from the main controls
- default board size to `5` in the script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846c2f1cbb48327a0b1a6ea6f0f19f7