### PR TITLE
Add responsive design for mobile and tablet

### DIFF
--- a/style.css
+++ b/style.css
@@ -258,6 +258,8 @@ select {
     animation: parpadeo 1s infinite;
     background: radial-gradient(circle at center, #d2b48c, #8b4513);
     color: #fff;
+    transform: scale(1.3);
+    z-index: 5;
 }
 
 button:disabled {
@@ -321,3 +323,27 @@ button:disabled {
 .eft2 span:nth-child(10n + 8) { color: orange; text-decoration: underline; }
 .eft2 span:nth-child(10n + 9) { color: white; background-color: purple; font-size: 150%; border-radius: 15px; padding: 3px; }
 .eft2 span:nth-child(10n + 10) { color: navy; }
+
+/* Ajustes responsivos para tablet y móvil */
+@media (max-width: 1024px) {
+    button {
+        padding: 8px 15px;
+        font-size: 14px;
+    }
+    .tarjeta {
+        font-size: 1em;
+    }
+}
+
+@media (max-width: 600px) {
+    button {
+        padding: 4px 8px;
+        font-size: 12px;
+    }
+    .tarjeta {
+        font-size: 0.8em;
+    }
+    #tablero {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- scale selected cards for clarity
- add responsive CSS for tablet and mobile buttons and text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846c460e35083278da2597b954da282