### PR TITLE
Add animated text effect to main buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -50,17 +50,16 @@ document.addEventListener('DOMContentLoaded', () => {
         mensajeVictoria.classList.add('oculto');
     });
 
-    function colorearTitulo() {
-        const titulo = document.querySelector('h1.eft2');
-        const texto = titulo.textContent;
-        titulo.innerHTML = '';
+    function colorearTexto(elemento) {
+        const texto = elemento.textContent;
+        elemento.innerHTML = '';
         [...texto].forEach(letra => {
             if (letra === ' ') {
-                titulo.appendChild(document.createTextNode(' '));
+                elemento.appendChild(document.createTextNode(' '));
             } else {
                 const span = document.createElement('span');
                 span.textContent = letra;
-                titulo.appendChild(span);
+                elemento.appendChild(span);
             }
         });
     }
@@ -260,7 +259,16 @@ document.addEventListener('DOMContentLoaded', () => {
         botonConfirmar.disabled = true;
     });
 
-    colorearTitulo();
+    const titulo = document.querySelector('h1.eft2');
+    colorearTexto(titulo);
+
+    ['nuevoJuego', 'vistaEspia', 'terminarTurno', 'tabletMode'].forEach(id => {
+        const btn = document.getElementById(id);
+        if (btn) {
+            btn.classList.add('eft2-text');
+            colorearTexto(btn);
+        }
+    });
     cargarPalabras().then(iniciarJuego);
 
 });

--- a/style.css
+++ b/style.css
@@ -322,3 +322,16 @@ button:disabled {
 .eft2 span:nth-child(10n + 8) { color: orange; text-decoration: underline; }
 .eft2 span:nth-child(10n + 9) { color: white; background-color: purple; font-size: 150%; border-radius: 15px; padding: 3px; }
 .eft2 span:nth-child(10n + 10) { color: navy; }
+
+/* Solo efecto en el texto (sin fondo) */
+.eft2-text span { display: inline-block; }
+.eft2-text span:nth-child(10n + 1) { color: blue; }
+.eft2-text span:nth-child(10n + 2) { color: white; background-color: red; font-size: 120%; }
+.eft2-text span:nth-child(10n + 3) { color: green; }
+.eft2-text span:nth-child(10n + 4) { color: #fff; text-decoration: underline; }
+.eft2-text span:nth-child(10n + 5) { color: pink; font-style: italic; }
+.eft2-text span:nth-child(10n + 6) { color: skyblue; font-style: italic; }
+.eft2-text span:nth-child(10n + 7) { color: yellowgreen; text-decoration: underline; }
+.eft2-text span:nth-child(10n + 8) { color: orange; text-decoration: underline; }
+.eft2-text span:nth-child(10n + 9) { color: white; background-color: purple; font-size: 150%; border-radius: 15px; padding: 3px; }
+.eft2-text span:nth-child(10n + 10) { color: navy; }


### PR DESCRIPTION
## Summary
- create a reusable `colorearTexto` function
- apply text effect to four main buttons without changing their backgrounds
- add `.eft2-text` CSS class with same styles as title effect

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6846c58efcd483278298b4accec0557b