### PR TITLE
Responsive tweaks for phones

### DIFF
--- a/style.css
+++ b/style.css
@@ -351,8 +351,21 @@ button:disabled {
     }
     .tarjeta {
         font-size: 0.8em;
+        transform: rotate(90deg);
+    }
+    .tarjeta:hover {
+        transform: rotate(90deg) scale(1.05);
+    }
+    .tarjeta.revelada {
+        transform: rotate(90deg);
+    }
+    .tarjeta.seleccionada {
+        transform: rotate(90deg) scale(1.3);
     }
     #tablero {
         width: 100%;
+    }
+    h1.eft2 {
+        font-size: 2rem;
     }
 }


### PR DESCRIPTION
## Summary
- rotate cards sideways on phones
- shrink the game title for small screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846c7eb4f008327955c650bda529bf1