### PR TITLE
Agrega aviso de espía asesinado

### DIFF
--- a/script.js
+++ b/script.js
@@ -341,10 +341,16 @@ document.addEventListener('DOMContentLoaded', () => {
         azulRestantes.textContent = restantes.azul;
     }
 
-    function mostrarMensajeVictoria(equipo) {
+    function mostrarMensajeVictoria(equipo, asesinado = null) {
         mensajeVictoria.innerHTML = equipo === 'rojo'
             ? '🔴 <strong>¡VICTORIA ROJA!</strong> 🎉'
             : '🔵 <strong>¡VICTORIA AZUL!</strong> 🎉';
+
+        if (asesinado) {
+            const emoji = asesinado === 'rojo' ? '🔴' : '🔵';
+            mensajeVictoria.innerHTML += `<br>${emoji} El espía ${asesinado} ha sido asesinado`;
+        }
+
         mensajeVictoria.classList.remove('rojo', 'azul', 'oculto');
         mensajeVictoria.classList.add(equipo);
     }
@@ -481,7 +487,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (tarjeta.dataset.rol === 'asesino') {
             juegoTerminado = true;
             const ganador = equipoActual === 'rojo' ? 'azul' : 'rojo';
-            mostrarMensajeVictoria(ganador);
+            mostrarMensajeVictoria(ganador, equipoActual);
         } else {
             if (tarjeta.dataset.rol === 'rojo' || tarjeta.dataset.rol === 'azul') {
                 restantes[tarjeta.dataset.rol]--;


### PR DESCRIPTION
## Summary
- añadir parámetro opcional en `mostrarMensajeVictoria` para indicar al espía asesinado
- mostrar el mensaje de espía eliminado junto con la victoria del equipo contrario

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846c90284fc8327b5b58b47687b7c61