### PR TITLE
Add interactive tooltip with game instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,34 @@
         <button id="vistaEspia">Ver/Ocultar Vista del Espía</button>
         <button id="terminarTurno">Terminar Turno</button>
         <button id="tabletMode">📱 Tablet Mode</button>
+        <div class="tooltip-container">
+            <span id="icono-ayuda">?</span>
+            <div id="tooltip-ayuda" class="tooltip-oculto">
+                <h3>¿Cómo Jugar a Código Secreto?</h3>
+                <p>
+                    El objetivo es que tu equipo adivine todas sus palabras antes que el equipo contrario. Un jugador de cada equipo es el "Jefe de Espías" y da pistas de una sola palabra para que sus compañeros adivinen.
+                </p>
+                <hr>
+                <ul>
+                    <li>
+                        <span class="color-caja azul"></span>
+                        <strong>Tarjeta de tu equipo (Azul):</strong> ¡Correcto! Tu equipo suma un punto y puedes seguir adivinando otra palabra.
+                    </li>
+                    <li>
+                        <span class="color-caja rojo"></span>
+                        <strong>Tarjeta del otro equipo (Roja):</strong> ¡Oh, no! Has ayudado al equipo contrario. Tu turno termina inmediatamente.
+                    </li>
+                    <li>
+                        <span class="color-caja amarillo"></span>
+                        <strong>Tarjeta Neutral (Civil):</strong> No pasa nada, pero tu turno termina.
+                    </li>
+                    <li>
+                        <span class="color-caja negro"></span>
+                        <strong>Tarjeta del Asesino:</strong> ¡Partida terminada! Si eliges esta tarjeta, tu equipo pierde inmediatamente.
+                    </li>
+                </ul>
+            </div>
+        </div>
     </div>
     <div id="informacion">
         <p id="turno"></p>

--- a/script.js
+++ b/script.js
@@ -497,6 +497,25 @@ document.addEventListener('DOMContentLoaded', () => {
         botonConfirmar.disabled = true;
     });
 
+    /* --- Lógica para el Tooltip de Ayuda --- */
+    const iconoAyuda = document.getElementById('icono-ayuda');
+    const tooltipAyuda = document.getElementById('tooltip-ayuda');
+
+    iconoAyuda.addEventListener('click', (event) => {
+        event.stopPropagation();
+        tooltipAyuda.classList.toggle('tooltip-oculto');
+    });
+
+    window.addEventListener('click', () => {
+        if (!tooltipAyuda.classList.contains('tooltip-oculto')) {
+            tooltipAyuda.classList.add('tooltip-oculto');
+        }
+    });
+
+    tooltipAyuda.addEventListener('click', (event) => {
+        event.stopPropagation();
+    });
+
     colorearTitulo();
     cargarPalabras().then(iniciarJuego);
 

--- a/style.css
+++ b/style.css
@@ -369,3 +369,109 @@ button:disabled {
         font-size: 2rem;
     }
 }
+
+/* --- Estilos para el Tooltip de Ayuda --- */
+
+/* Contenedor para posicionar el tooltip */
+.tooltip-container {
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+/* Estilo del icono '?' */
+#icono-ayuda {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 30px;
+    height: 30px;
+    background-color: #6c757d;
+    color: white;
+    font-weight: bold;
+    font-size: 20px;
+    border-radius: 50%;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color 0.2s;
+}
+
+#icono-ayuda:hover {
+    background-color: #5a6268;
+}
+
+/* Estilo de la ventana del tooltip */
+#tooltip-ayuda {
+    position: absolute;
+    bottom: 125%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 320px;
+    background-color: #fff;
+    color: #333;
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+    text-align: left;
+    line-height: 1.5;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+/* Flecha del tooltip */
+#tooltip-ayuda::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -8px;
+    border-width: 8px;
+    border-style: solid;
+    border-color: #fff transparent transparent transparent;
+}
+
+/* Clase para ocultar/mostrar el tooltip */
+.tooltip-oculto {
+    opacity: 0;
+    visibility: hidden;
+    transform: translateX(-50%) translateY(10px);
+}
+
+/* Estilos para el contenido del tooltip */
+#tooltip-ayuda h3 {
+    margin-top: 0;
+    color: #007bff;
+}
+
+#tooltip-ayuda hr {
+    border: none;
+    border-top: 1px solid #eee;
+    margin: 10px 0;
+}
+
+#tooltip-ayuda ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#tooltip-ayuda li {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+/* Pequeños cuadrados de color para la explicación */
+.color-caja {
+    width: 18px;
+    height: 18px;
+    border-radius: 4px;
+    margin-right: 10px;
+    flex-shrink: 0;
+    border: 1px solid rgba(0,0,0,0.1);
+}
+
+.color-caja.azul { background-color: #a0c4ff; }
+.color-caja.rojo { background-color: #ffadad; }
+.color-caja.amarillo { background-color: #fdffb6; }
+.color-caja.negro { background-color: #444; }


### PR DESCRIPTION
## Summary
- add help icon with tooltip describing game rules
- style tooltip appearance
- implement JS to show/hide tooltip

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846c94aa02c8327a21f049dd66371f6