### PR TITLE
Fix tooltip position for help icon

### DIFF
--- a/style.css
+++ b/style.css
@@ -403,7 +403,8 @@ button:disabled {
 /* Estilo de la ventana del tooltip */
 #tooltip-ayuda {
     position: absolute;
-    bottom: 125%;
+    top: 125%;
+    bottom: auto;
     left: 50%;
     transform: translateX(-50%);
     width: 320px;
@@ -422,19 +423,19 @@ button:disabled {
 #tooltip-ayuda::after {
     content: '';
     position: absolute;
-    top: 100%;
+    bottom: 100%;
     left: 50%;
     margin-left: -8px;
     border-width: 8px;
     border-style: solid;
-    border-color: #fff transparent transparent transparent;
+    border-color: transparent transparent #fff transparent;
 }
 
 /* Clase para ocultar/mostrar el tooltip */
 .tooltip-oculto {
     opacity: 0;
     visibility: hidden;
-    transform: translateX(-50%) translateY(10px);
+    transform: translateX(-50%) translateY(-10px);
 }
 
 /* Estilos para el contenido del tooltip */


### PR DESCRIPTION
## Summary
- display the help tooltip below the `?` icon
- update arrow direction and transition

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846cad742e083279502b42482d8cf6d