### PR TITLE
Add emoji toggle control

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,10 @@
     <main>
     <div class="controles">
         <button id="nuevoJuego">Nuevo Juego</button>
-        <button id="vistaEspia">Ver/Ocultar Vista del Espía</button>
+        <button id="vistaEspia" class="toggle-btn">Ver/Ocultar Vista del Espía</button>
         <button id="terminarTurno">Terminar Turno</button>
-        <button id="tabletMode">📱 Tablet Mode</button>
+        <button id="tabletMode" class="toggle-btn">📱 Tablet Mode</button>
+        <button id="emojiToggle" class="toggle-btn">😀 Emojis</button>
     </div>
     <div id="informacion">
         <p id="turno"></p>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const botonNuevoJuego = document.getElementById('nuevoJuego');
     const botonVistaEspia = document.getElementById('vistaEspia');
     const botonTabletMode = document.getElementById('tabletMode');
+    const botonEmojiToggle = document.getElementById('emojiToggle');
 
     const botonTerminarTurno = document.getElementById('terminarTurno');
     const botonConfirmar = document.getElementById('confirmar');
@@ -15,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const comenzarJuegoBtn = document.getElementById('comenzarJuego');
     const cancelarJuegoBtn = document.getElementById('cancelarJuego');
     const modoRadios = document.getElementsByName('modoJuego');
+    let emojisVisibles = true;
 
     const emojiA1Map = {
         "pelo": "\uD83D\uDC88",
@@ -252,6 +254,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const emoji = emojiA1Map[palabra];
         return emoji ? `${palabra} ${emoji}` : palabra;
     }
+    function actualizarEmojis() {
+        document.querySelectorAll(".tarjeta").forEach(t => {
+            const palabra = t.dataset.palabra;
+            t.textContent = emojisVisibles ? aplicarEmojiA1(palabra) : palabra;
+        });
+    }
 
     modoRadios.forEach(r => r.addEventListener('change', actualizarPalabrasInput));
     tooltipGrid.addEventListener('change', actualizarPalabrasInput);
@@ -368,6 +376,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         tablero.innerHTML = '';
         tablero.classList.remove('vista-espia');
+        botonVistaEspia.classList.remove('active');
 
         const totalCasillas = tamanoActual * tamanoActual;
         const palabrasJuego = palabrasBase.sort(() => 0.5 - Math.random()).slice(0, totalCasillas);
@@ -394,7 +403,7 @@ document.addEventListener('DOMContentLoaded', () => {
         palabrasJuego.forEach((palabra, i) => {
             const tarjeta = document.createElement('div');
             tarjeta.classList.add('tarjeta');
-            tarjeta.textContent = aplicarEmojiA1(palabra);
+            tarjeta.textContent = emojisVisibles ? aplicarEmojiA1(palabra) : palabra;
             tarjeta.dataset.rol = roles[i];
             tarjeta.dataset.palabra = palabra;
             tarjeta.addEventListener('click', () => {
@@ -457,11 +466,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     botonVistaEspia.addEventListener('click', () => {
-        tablero.classList.toggle('vista-espia');
+        const activa = tablero.classList.toggle('vista-espia');
+        botonVistaEspia.classList.toggle('active', activa);
     });
-
     botonTabletMode.addEventListener('click', () => {
-        tablero.classList.toggle('modo-tablet');
+        const activa = tablero.classList.toggle('modo-tablet');
+        botonTabletMode.classList.toggle('active', activa);
+    });
+    botonEmojiToggle.addEventListener('click', () => {
+        emojisVisibles = !emojisVisibles;
+        botonEmojiToggle.classList.toggle('active', emojisVisibles);
+        actualizarEmojis();
     });
 
 
@@ -497,6 +512,7 @@ document.addEventListener('DOMContentLoaded', () => {
         botonConfirmar.disabled = true;
     });
 
+    botonEmojiToggle.classList.add("active");
     colorearTitulo();
     cargarPalabras().then(iniciarJuego);
 

--- a/style.css
+++ b/style.css
@@ -59,6 +59,14 @@ button {
     margin: 5px;
     transition: transform 0.2s, box-shadow 0.2s;
 }
+.toggle-btn {
+    filter: brightness(0.85);
+}
+
+.toggle-btn.active {
+    filter: none;
+    background-image: linear-gradient(45deg, var(--blood-red), var(--tyrian-purple));
+}
 
 button:hover {
     transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- add new emoji toggle button
- highlight spy/tablet/emoji buttons when active
- dim inactive toggle buttons
- ensure spy view resets when starting a new game

## Testing
- `bash -lc 'npm test'` *(fails: no such script)*

------
https://chatgpt.com/codex/tasks/task_e_6846c9a25d6c83278613673b26a463f1