### PR TITLE
Invert config tooltip colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -227,7 +227,8 @@ select {
     z-index: 1000;
 }
 .tooltip-contenido {
-    background: #fff;
+    background: #000;
+    color: #fff;
     padding: 20px;
     border-radius: 8px;
     width: 90%;


### PR DESCRIPTION
## Summary
- switch tooltip background to black and text to white for the create game tooltip

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846cf9ff2bc8327ae4a93671c1cc6f4