### PR TITLE
Increase horizontal gap in mobile view

### DIFF
--- a/style.css
+++ b/style.css
@@ -373,7 +373,7 @@ button:disabled {
     }
     #tablero {
         width: 100%;
-        gap: 5px 20px;
+        gap: 5px 50px;
     }
     h1.eft2 {
         font-size: 2rem;


### PR DESCRIPTION
## Summary
- widen the column gap for the board on small screens so cards don't overlap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d13040988327b541e43450b6c4a6