### PR TITLE
Adjust tooltip width for desktop and mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -417,7 +417,8 @@ button:disabled {
     bottom: auto;
     left: 50%;
     transform: translateX(-50%);
-    width: 320px;
+    width: 80vw;
+    max-width: 600px;
     background-color: #fff;
     color: #333;
     padding: 15px;
@@ -427,6 +428,13 @@ button:disabled {
     text-align: left;
     line-height: 1.5;
     transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+@media (max-width: 600px) {
+    #tooltip-ayuda {
+        width: 60vw;
+        max-width: none;
+    }
 }
 
 /* Flecha del tooltip */


### PR DESCRIPTION
## Summary
- make the help tooltip wider on large screens
- shrink the tooltip on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d2a17d68832797a46cb1662f3659