### PR TITLE
Improve toggle buttons visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@
     <div class="controles">
 
         <button id="nuevoJuego">🆕 Nuevo Juego</button>
-        <button id="vistaEspia">🕵️ Ver/Ocultar Vista del Espía</button>
+        <button id="vistaEspia" class="toggle-btn">🕵️ Ver/Ocultar Vista del Espía</button>
         <button id="terminarTurno">⏭️ Terminar Turno</button>
-        <button id="tabletMode">📱 Tablet Mode</button>
+        <button id="tabletMode" class="toggle-btn">📱 Tablet Mode</button>
         <button id="emojiToggle" class="toggle-btn">😀 Emojis</button>
         <div class="tooltip-container">
             <span id="icono-ayuda">?</span>

--- a/style.css
+++ b/style.css
@@ -59,13 +59,15 @@ button {
     margin: 5px;
     transition: transform 0.2s, box-shadow 0.2s;
 }
+
 .toggle-btn {
-    filter: brightness(0.85);
+    filter: grayscale(1) brightness(0.8);
 }
 
 .toggle-btn.active {
     filter: none;
     background-image: linear-gradient(45deg, var(--blood-red), var(--tyrian-purple));
+    box-shadow: 0 0 8px rgba(0,0,0,0.3);
 }
 
 button:hover {


### PR DESCRIPTION
## Summary
- colorize toggle buttons for spy view, tablet mode and emojis
- show toggles grey when inactive and highlight when active

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846d575d2448327860f51511bc2553b