### PR TITLE
Fix tooltip overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -416,7 +416,7 @@ button:disabled {
     top: 125%;
     bottom: auto;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(-80%);
     width: 80vw;
     max-width: 600px;
     background-color: #fff;
@@ -453,7 +453,7 @@ button:disabled {
 .tooltip-oculto {
     opacity: 0;
     visibility: hidden;
-    transform: translateX(-50%) translateY(-10px);
+    transform: translateX(-80%) translateY(-10px);
 }
 
 /* Estilos para el contenido del tooltip */


### PR DESCRIPTION
## Summary
- shift help tooltip 30% further left so it no longer flows off screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d5bf23848327bdd88edb3fd4b38d