### PR TITLE
Fix assassin text color in spy tablet mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -164,6 +164,12 @@ select {
     color: #fff;
 }
 
+/* Asegura que el texto de la tarjeta asesino sea blanco
+   cuando coinciden los modos vista espía y tablet */
+#tablero.modo-tablet.vista-espia .tarjeta.asesino {
+    color: #fff;
+}
+
 
 .vista-espia .tarjeta.rojo { background-color: #ffadad; }
 .vista-espia .tarjeta.azul { background-color: #a0c4ff; }


### PR DESCRIPTION
## Summary
- ensure assassin card text stays white when spy view and tablet mode are active simultaneously

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846d998cba483278778cca6baf6b9e0