### PR TITLE
Use colored text instead of flag emoji for language switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="background">
-    <button id="languageToggle" class="lang-btn">🇬🇧</button>
+    <button id="languageToggle" class="lang-btn flag-gb">GB</button>
     <header>
         <h1 id="titulo" class="eft2">Palabras Clave</h1>
     </header>

--- a/script.js
+++ b/script.js
@@ -126,7 +126,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     botonIdioma.addEventListener('click', () => {
         idiomaActual = idiomaActual === 'es' ? 'en' : 'es';
-        botonIdioma.textContent = idiomaActual === 'es' ? '🇬🇧' : '🇪🇸';
+        if (idiomaActual === 'es') {
+            botonIdioma.textContent = 'GB';
+            botonIdioma.classList.remove('flag-es');
+            botonIdioma.classList.add('flag-gb');
+        } else {
+            botonIdioma.textContent = 'ES';
+            botonIdioma.classList.remove('flag-gb');
+            botonIdioma.classList.add('flag-es');
+        }
         aplicarTraduccion();
     });
 

--- a/style.css
+++ b/style.css
@@ -519,3 +519,36 @@ footer.credit {
     cursor: pointer;
     z-index: 1000;
 }
+
+.lang-btn.flag-gb,
+.lang-btn.flag-es {
+    font-weight: bold;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    color: transparent;
+}
+
+.lang-btn.flag-gb {
+    background-image: linear-gradient(
+        to bottom,
+        #00247d 0%,
+        #00247d 33%,
+        #ffffff 33%,
+        #ffffff 66%,
+        #cf142b 66%,
+        #cf142b 100%
+    );
+}
+
+.lang-btn.flag-es {
+    background-image: linear-gradient(
+        to bottom,
+        #aa151b 0%,
+        #aa151b 33%,
+        #f1bf00 33%,
+        #f1bf00 66%,
+        #aa151b 66%,
+        #aa151b 100%
+    );
+}


### PR DESCRIPTION
## Summary
- replace flag emoji with `GB` and `ES` text for language toggle
- apply CSS gradients to color the text with national flag colors
- update language toggle script to swap text and classes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68481e6b0c208327a481735591de1aa1